### PR TITLE
handles de-activation in DummyStepLogic

### DIFF
--- a/src/Zezo.Core.GrainInterfaces/IStepGrain.cs
+++ b/src/Zezo.Core.GrainInterfaces/IStepGrain.cs
@@ -47,7 +47,7 @@ namespace Zezo.Core.GrainInterfaces
         Task Resume();
 
         /// <summary>
-        /// Ons the stopping.
+        /// Stops the Step.
         /// </summary>
         Task Stop();
 
@@ -67,9 +67,20 @@ namespace Zezo.Core.GrainInterfaces
         Task OnChildStopped(Guid caller, ChildStoppedEventArgs eventArgs);
         
         // For client & unit testing
+        /// <summary>
+        /// This is for testing only.
+        /// Assumes the observer is always valid.
+        /// </summary>
+        /// <param name="observer"></param>
+        /// <returns></returns>
         Task Subscribe(IStepGrainObserver observer);
         Task Unsubscribe(IStepGrainObserver observer);
         
+        
+        // For Logic (background work)
+        [AlwaysInterleave]
+        Task _Call(string action, params object[] parameters);
+
     }
 
     public class ChildStatusChangedEventArgs : EventArgs

--- a/src/Zezo.Core.GrainInterfaces/IStepGrain.cs
+++ b/src/Zezo.Core.GrainInterfaces/IStepGrain.cs
@@ -76,8 +76,16 @@ namespace Zezo.Core.GrainInterfaces
         Task Subscribe(IStepGrainObserver observer);
         Task Unsubscribe(IStepGrainObserver observer);
         
-        
         // For Logic (background work)
+        
+        /// <summary>
+        /// Called by long running tasks spawned by the StepGrain to update its status.
+        /// This should be the only interface through which a long running non-Orleans thread
+        /// interact with the Grain state.
+        /// </summary>
+        /// <param name="action"></param>
+        /// <param name="parameters"></param>
+        /// <returns></returns>
         [AlwaysInterleave]
         Task _Call(string action, params object[] parameters);
 

--- a/src/Zezo.Core.GrainInterfaces/IStepLogic.cs
+++ b/src/Zezo.Core.GrainInterfaces/IStepLogic.cs
@@ -34,5 +34,9 @@ namespace Zezo.Core.GrainInterfaces
         Task HandleChildIdle(Guid caller);
 
         Task HandleChildStopped(Guid caller);
+        
+        
+        // Background callback
+        Task _Call(string action, params object[] parameters);
     }
 }

--- a/src/Zezo.Core.GrainInterfaces/StepGrainData.cs
+++ b/src/Zezo.Core.GrainInterfaces/StepGrainData.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using Zezo.Core.Configuration.Steps;
+using Zezo.Core.GrainInterfaces.Observers;
 
 namespace Zezo.Core.GrainInterfaces
 {
@@ -15,5 +16,8 @@ namespace Zezo.Core.GrainInterfaces
         public int ChildCount => ChildNodes.Count;
         public Dictionary<string, object> Data = new Dictionary<string, object>();
         public StepNode Config { get; set; }
+        
+        public HashSet<IStepGrainObserver> Observers = new HashSet<IStepGrainObserver>();
+        
     }
 }

--- a/src/Zezo.Core.GrainInterfaces/StepGrainData.cs
+++ b/src/Zezo.Core.GrainInterfaces/StepGrainData.cs
@@ -8,16 +8,17 @@ namespace Zezo.Core.GrainInterfaces
     public class StepGrainData
     {
         public StepStatus Status { get; set; } = StepStatus.Uninitialized;
-        public string Type { get; set; }
         public string Id { get; set; }
         public Guid? ParentNode { get; set; }
         public Guid Entity {get; set; }
-        public List<Guid> ChildNodes { get; set; } = new List<Guid>();
+        public List<Guid> ChildNodes { get; } = new List<Guid>();
         public int ChildCount => ChildNodes.Count;
         public Dictionary<string, object> Data = new Dictionary<string, object>();
         public StepNode Config { get; set; }
         
-        public HashSet<IStepGrainObserver> Observers = new HashSet<IStepGrainObserver>();
-        
+        /// <summary>
+        /// Client-side observers. (For test only).
+        /// </summary>
+        public HashSet<IStepGrainObserver> Observers { get; } = new HashSet<IStepGrainObserver>();
     }
 }

--- a/src/Zezo.Core.Grains/IContainer.cs
+++ b/src/Zezo.Core.Grains/IContainer.cs
@@ -24,7 +24,6 @@ namespace Zezo.Core.Grains {
         StepStatus Status { get; }
         StepGrainData State { get; }
         
-        IGrainFactory GrainFactory {get;}
         IStepGrain SelfReference { get;  }
 
         // Status changes

--- a/src/Zezo.Core.Grains/IContainer.cs
+++ b/src/Zezo.Core.Grains/IContainer.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
+using Orleans;
 using Zezo.Core.Configuration.Steps;
 using Zezo.Core.GrainInterfaces;
 
@@ -22,6 +23,9 @@ namespace Zezo.Core.Grains {
         ILogger Logger { get; }
         StepStatus Status { get; }
         StepGrainData State { get; }
+        
+        IGrainFactory GrainFactory {get;}
+        IStepGrain SelfReference { get;  }
 
         // Status changes
         Task CompleteSelf(bool success);

--- a/src/Zezo.Core.Grains/StepGrain.ClientObserver.cs
+++ b/src/Zezo.Core.Grains/StepGrain.ClientObserver.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Threading.Tasks;
 using Zezo.Core.GrainInterfaces.Observers;
 
@@ -7,14 +9,101 @@ namespace Zezo.Core.Grains
     {
         public Task Subscribe(IStepGrainObserver observer)
         {
-            _subsManager.Subscribe(observer);
-            return Task.CompletedTask;
+            State.Observers.Add(observer);
+            return WriteStateAsync();
         }
 
         public Task Unsubscribe(IStepGrainObserver observer)
         {
-            _subsManager.Unsubscribe(observer);
-            return Task.CompletedTask;
+            State.Observers.Remove(observer);
+            return WriteStateAsync();
+        }
+        
+        /// <summary>
+        /// Notifies all observers.
+        /// </summary>
+        /// <param name="notification">
+        /// The notification delegate to call on each observer.
+        /// </param>
+        /// <param name="predicate">The predicate used to select observers to notify.</param>
+        /// <returns>
+        /// A <see cref="Task"/> representing the work performed.
+        /// </returns>
+        private async Task Notify(Func<IStepGrainObserver, Task> notification, Func<IStepGrainObserver, bool> predicate = null)
+        {
+            var defunct = default(List<IStepGrainObserver>);
+            foreach (var observer in State.Observers)
+            {
+                // Skip observers which don't match the provided predicate.
+                if (predicate != null && !predicate(observer))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    await notification(observer);
+                }
+                catch (Exception)
+                {
+                    // Failing observers are considered defunct and will be removed..
+                    defunct = defunct ?? new List<IStepGrainObserver>();
+                    defunct.Add(observer);
+                }
+            }
+
+            // Remove defunct observers.
+            if (defunct != default(List<IStepGrainObserver>))
+            {
+                foreach (var observer in defunct)
+                {
+                    State.Observers.Remove(observer);
+                }
+
+                await WriteStateAsync();
+            }
+        }
+        
+        /// <summary>
+        /// Notifies all observers which match the provided <paramref name="predicate"/>.
+        /// </summary>
+        /// <param name="notification">
+        /// The notification delegate to call on each observer.
+        /// </param>
+        /// <param name="predicate">The predicate used to select observers to notify.</param>
+        private void Notify(Action<IStepGrainObserver> notification, Func<IStepGrainObserver, bool> predicate = null)
+        {
+            var defunct = default(List<IStepGrainObserver>);
+            foreach (var observer in State.Observers)
+            {
+                // Skip observers which don't match the provided predicate.
+                if (predicate != null && !predicate(observer))
+                {
+                    continue;
+                }
+
+                try
+                {
+                    notification(observer);
+                }
+                catch (Exception)
+                {
+                    // Failing observers are considered defunct and will be removed..
+                    defunct = defunct ?? new List<IStepGrainObserver>();
+                    defunct.Add(observer);
+                }
+            }
+
+            // Remove defunct observers.
+            if (defunct != default(List<IStepGrainObserver>))
+            {
+                foreach (var observer in defunct)
+                {
+                    State.Observers.Remove(observer);
+                }
+
+                WriteStateAsync();
+            }
         }
     }
 }

--- a/src/Zezo.Core.Grains/StepGrain.Container.cs
+++ b/src/Zezo.Core.Grains/StepGrain.Container.cs
@@ -9,7 +9,6 @@ namespace Zezo.Core.Grains
 {
     public partial class StepGrain : IContainer
     {        
-        
         public ILogger Logger => logger;
 
         public StepStatus Status => State?.Status ?? StepStatus.Uninitialized;
@@ -19,8 +18,6 @@ namespace Zezo.Core.Grains
         IStepGrain IContainer.SelfReference => GrainFactory.GetGrain<IStepGrain>(SelfKey);
 
         public Guid SelfKey => this.GetPrimaryKey();
-
-        IGrainFactory IContainer.GrainFactory => this.GrainFactory;
 
         public async Task CompleteSelf(bool success)
         {

--- a/src/Zezo.Core.Grains/StepGrain.Container.cs
+++ b/src/Zezo.Core.Grains/StepGrain.Container.cs
@@ -16,8 +16,12 @@ namespace Zezo.Core.Grains
 
         StepGrainData IContainer.State => this.State;
 
+        IStepGrain IContainer.SelfReference => GrainFactory.GetGrain<IStepGrain>(SelfKey);
+
         public Guid SelfKey => this.GetPrimaryKey();
-        
+
+        IGrainFactory IContainer.GrainFactory => this.GrainFactory;
+
         public async Task CompleteSelf(bool success)
         {
             if (State.Status == StepStatus.Inactive ||
@@ -73,6 +77,7 @@ namespace Zezo.Core.Grains
         {
             var entityGrain = GetEntityGrain();
             return entityGrain.SpawnChild(childConfig, SelfKey);
+            
         }
 
         public IEntityGrain GetEntityGrain()

--- a/src/Zezo.Core.Grains/StepLogic/BaseStepLogic.cs
+++ b/src/Zezo.Core.Grains/StepLogic/BaseStepLogic.cs
@@ -32,5 +32,9 @@ namespace Zezo.Core.Grains.StepLogic {
 
         public abstract Task HandleChildStopped(Guid caller);
 
+        public virtual Task _Call(string action, params object[] parameters)
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Zezo.Silo/Program.cs
+++ b/src/Zezo.Silo/Program.cs
@@ -34,6 +34,7 @@ namespace Zezo.Silo
             var builder = new SiloHostBuilder()
                 .UseLocalhostClustering()
                 .AddMemoryGrainStorage("DevStore")
+                .EnableDirectClient()
                 .Configure<ClusterOptions>(options => {
                     options.ClusterId = "dev";
                     options.ServiceId = "Zezo";

--- a/test/Zezo.Core.Grains.Tests/BaseGrainTest.cs
+++ b/test/Zezo.Core.Grains.Tests/BaseGrainTest.cs
@@ -81,6 +81,7 @@ namespace Zezo.Core.Grains.Tests
         {
             hostBuilder
                 .AddMemoryGrainStorage("DevStore")
+                .EnableDirectClient()
 #if SiloLogging
                 .ConfigureLogging(logging => 
                     logging.AddConsole());

--- a/test/Zezo.Core.Grains.Tests/BaseGrainTest.cs
+++ b/test/Zezo.Core.Grains.Tests/BaseGrainTest.cs
@@ -1,4 +1,4 @@
-#define SiloLogging
+//#define SiloLogging
 
 using System;
 using System.Threading.Tasks;

--- a/test/Zezo.Core.Grains.Tests/TestObserver.cs
+++ b/test/Zezo.Core.Grains.Tests/TestObserver.cs
@@ -17,6 +17,7 @@ namespace Zezo.Core.Grains.Tests
         private readonly IGrainFactory _grainFactory;
         private readonly ITestOutputHelper _testOutputHelper;
         private IStepGrainObserver selfReference = null;
+        public TimeSpan WaitingTimeout { get; set; } = TimeSpan.FromSeconds(30);
 
         private Task<IStepGrainObserver> SelfReference
         {
@@ -115,8 +116,8 @@ namespace Zezo.Core.Grains.Tests
             
             Task.Run(async () =>
             {
-                await Task.Delay(5000);
-                //tcs.TrySetException(new TimeoutException());
+                await Task.Delay(WaitingTimeout);
+                tcs.TrySetException(new TimeoutException());
             });
             
             

--- a/test/Zezo.Core.Grains.Tests/TestObserver.cs
+++ b/test/Zezo.Core.Grains.Tests/TestObserver.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using System.Timers;
 using Orleans;
 using Xunit;
 using Xunit.Abstractions;
@@ -107,9 +108,17 @@ namespace Zezo.Core.Grains.Tests
                 }
             }
 
+            
             // if already waiting
             TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
             awaitingTasks[stepId].Add((predicate, tcs));            
+            
+            Task.Run(async () =>
+            {
+                await Task.Delay(5000);
+                //tcs.TrySetException(new TimeoutException());
+            });
+            
             
             return tcs.Task;
         }


### PR DESCRIPTION
Previously, `DummyStepLogic` spawns a long-running thread that runs independently of the Grain thread. When the long-running job completes, it needs to update the Step status in the Grain. Doing so when the Grain has been de-activated will cause an access violation.

The solution is to use DirectClient support in Orleans and let the long running thread delegate schedule a grain call to set its status. `_Call` on the `IStepGrain` interface is introduced for this purpose.